### PR TITLE
Make tab-width and indent-line-function buffer-local

### DIFF
--- a/ssass-mode.el
+++ b/ssass-mode.el
@@ -229,8 +229,8 @@ If FILENAME is nil, it will open the current buffer's file"
 (define-derived-mode ssass-mode prog-mode "Ssass"
   "Major mode for Sass"
   (setq-local electric-indent-mode nil)
-  (setq tab-width ssass-tab-width)
-  (setq indent-line-function 'ssass-indent)
+  (set (make-local-variable 'tab-width) ssass-tab-width)
+  (set (make-local-variable 'indent-line-function) 'ssass-indent)
   (font-lock-add-keywords nil ssass-font-lock-keywords)
   (modify-syntax-entry ?/ ". 124" ssass-mode-syntax-table)
   (modify-syntax-entry ?* ". 23b" ssass-mode-syntax-table)


### PR DESCRIPTION
When we set this globally, we intrude on packages which doesn't
explicitly set these variables. I observed this with mutt-mode.