### PR TITLE
Improve commenting in mmm-mode

### DIFF
--- a/ssass-mode.el
+++ b/ssass-mode.el
@@ -230,6 +230,7 @@ If FILENAME is nil, it will open the current buffer's file"
   "Major mode for Sass"
   (setq-local electric-indent-mode nil)
   (set (make-local-variable 'tab-width) ssass-tab-width)
+  (set (make-local-variable 'comment-start) "//")
   (set (make-local-variable 'indent-line-function) 'ssass-indent)
   (font-lock-add-keywords nil ssass-font-lock-keywords)
   (modify-syntax-entry ?/ ". 124" ssass-mode-syntax-table)


### PR DESCRIPTION
Currently commenting in `mmm-mode` is just totally broken for me without this line. My particular use case is using this mode with `vue-mode`, and I just can't comment any Sass sections.

So this adds `//` to the `comment-start` variable so we can successfully comment in Sass blocks.

I'm not an emacs expert, so I'm sure there's actually more stuff we could add here to support multiline commenting and stuff, but I actually prefer only doing single lines anyways. But if someone would like to add the other vars like `comment-end` and stuff, that'd probably be a good idea.